### PR TITLE
feat: add inline subflow expansion

### DIFF
--- a/UI/src/app/flows/Flow.tsx
+++ b/UI/src/app/flows/Flow.tsx
@@ -44,6 +44,7 @@ const style = {
 interface IFlowParams {
   id: number;
   readOnly?: boolean;
+  preloaded?: IFlowOutputModel;
 }
 
 export interface IFlowSelection {
@@ -71,6 +72,8 @@ export interface IConnectorObservable {
 export interface INodeObservable {
   model: ObservableValue<IFlowNodeOutputModel>;
   connectors: ObservableValue<IConnectorObservable>[];
+  isExpanded: ObservableValue<boolean>;
+  subFlow?: ObservableValue<IFlowOutputModel | undefined>;
 }
 
 export interface IPinObservable {
@@ -78,7 +81,7 @@ export interface IPinObservable {
   node: INodeObservable;
 }
 
-export default function Flow({ id, readOnly }: IFlowParams) {
+export default function Flow({ id, readOnly, preloaded }: IFlowParams) {
   const flowPanelRef = React.createRef<HTMLDivElement>();
   const draggableWrapperRef = React.createRef<HTMLDivElement>();
 
@@ -87,6 +90,7 @@ export default function Flow({ id, readOnly }: IFlowParams) {
   const [openSubFlow, setOpenSubFlow] = React.useState<number | null>(null);
 
   const selection = useObservable<IFlowSelection>({ flow: id });
+  const subFlowsCache = React.useRef<Record<number, IFlowOutputModel>>({});
 
   const flow: IFlowObservable = {
     id: id,
@@ -134,7 +138,12 @@ export default function Flow({ id, readOnly }: IFlowParams) {
         response.x = response.x || flowPanelSize.width / 2 - flow.position.x;
         response.y = response.y || flowPanelSize.height / 2 - flow.position.y;
 
-        const node = { model: new ObservableValue(response), connectors: [] };
+        const node: INodeObservable = {
+          model: new ObservableValue(response),
+          connectors: [],
+          isExpanded: new ObservableValue(false),
+          subFlow: new ObservableValue<IFlowOutputModel | undefined>(undefined),
+        };
 
         flow.nodes.value = [...flow.nodes.value, node];
 
@@ -219,8 +228,25 @@ export default function Flow({ id, readOnly }: IFlowParams) {
       success: (template) => {
         updateKeys([template]);
         template.subFlowId = flowId;
-        const node = { model: new ObservableValue(template), connectors: [] };
+        const node: INodeObservable = {
+          model: new ObservableValue(template),
+          connectors: [],
+          isExpanded: new ObservableValue(false),
+          subFlow: new ObservableValue<IFlowOutputModel | undefined>(undefined),
+        };
         flow.nodes.value = [...flow.nodes.value, node];
+
+        const cached = subFlowsCache.current[flowId];
+        if (cached) {
+          node.subFlow!.value = cached;
+        } else {
+          api.flow.get(flowId, {
+            success: (res) => {
+              subFlowsCache.current[flowId] = res;
+              node.subFlow!.value = res;
+            },
+          });
+        }
       },
     });
     setModalOpen(false);
@@ -266,6 +292,8 @@ export default function Flow({ id, readOnly }: IFlowParams) {
     flow.nodes.value = model.nodes.map<INodeObservable>((x) => ({
       model: new ObservableValue(x),
       connectors: [],
+      isExpanded: new ObservableValue(false),
+      subFlow: new ObservableValue<IFlowOutputModel | undefined>(undefined),
     }));
     onDrag({ x: model.x, y: model.y });
 
@@ -276,6 +304,8 @@ export default function Flow({ id, readOnly }: IFlowParams) {
     const addedNodes = model.nodes.map<INodeObservable>((x) => ({
       model: new ObservableValue(x),
       connectors: [],
+      isExpanded: new ObservableValue(false),
+      subFlow: new ObservableValue<IFlowOutputModel | undefined>(undefined),
     }));
     onDrag({ x: model.x, y: model.y });
 
@@ -426,7 +456,15 @@ export default function Flow({ id, readOnly }: IFlowParams) {
     }
   };
 
-  loadFlow();
+  React.useEffect(() => {
+    if (preloaded) {
+      updateKeys(preloaded.nodes);
+      updateFlowObservable(preloaded);
+    } else {
+      loadFlow();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [id, preloaded]);
 
   return (
     <>

--- a/UI/src/app/flows/components/Node/Node.scss
+++ b/UI/src/app/flows/components/Node/Node.scss
@@ -41,3 +41,13 @@
 .node:hover .open-flow-button {
   display: block;
 }
+
+.subflow-inline {
+  overflow: hidden;
+  max-height: 0;
+  transition: max-height 0.3s ease;
+}
+
+.subflow-inline.expanded {
+  max-height: 1000px;
+}

--- a/UI/src/app/flows/components/Node/Node.tsx
+++ b/UI/src/app/flows/components/Node/Node.tsx
@@ -8,6 +8,7 @@ import "./Node.scss";
 import {
   IFlowNodeOutputModel,
   IPinValueOutputModel,
+  IFlowOutputModel,
 } from "../../../models/output/flowOutput";
 import {
   NodeCommandType,
@@ -15,6 +16,7 @@ import {
   PinValueType,
 } from "../../../models/enums";
 import { Observer } from "../../../../utils/observable";
+import Flow from "../../Flow";
 import classNames from "classnames";
 import { Icon } from "@fluentui/react";
 import { useHistory } from "react-router";
@@ -68,8 +70,16 @@ export default function Node({
   };
 
   return (
-    <Observer model={observable.model}>
-      {(observer: { model: IFlowNodeOutputModel }) => {
+    <Observer
+      model={observable.model}
+      isExpanded={observable.isExpanded}
+      subFlow={observable.subFlow}
+    >
+      {(observer: {
+        model: IFlowNodeOutputModel;
+        isExpanded: boolean;
+        subFlow?: IFlowOutputModel;
+      }) => {
         let inputPin = observer.model.inputPins.find(
           (x) => x.valueType === PinValueType.Node
         );
@@ -100,89 +110,115 @@ export default function Node({
             }}
           >
             <div
-              className={classNames("card node d-flex flex-column noselect", {
-                "node-selected": selected,
-              })}
+              onMouseEnter={() => {
+                if (observer.model.subFlowId)
+                  observable.isExpanded.value = true;
+              }}
+              onMouseLeave={() => {
+                if (observer.model.subFlowId)
+                  observable.isExpanded.value = false;
+              }}
             >
-              {observer.model.commandType === NodeCommandType.Flow &&
-                observer.model.subFlowId && (
-                  <button
-                    className="open-flow-button"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      if (onOpenFlow) onOpenFlow(observer.model.subFlowId!);
-                      else history.push(`/flows/${observer.model.subFlowId}`);
-                    }}
-                  >
-                    <Icon iconName="OpenPane" />
-                  </button>
-                )}
-              <div className="d-flex flex-row justify-content-between">
-                {(inputPin && (
-                  <Pin
-                    key={inputPin.key}
-                    observable={pinToObservable(inputPin)}
-                    node={observable}
-                    hideName
-                    onPinsConnect={readOnly ? undefined : onPinsConnect}
-                  />
-                )) || (
-                  <PinGhost
-                    direction={PinDirection.Input}
-                    valueType={PinValueType.Node}
-                  />
-                )}
-                <span className="node-name font-weight-bold">
-                  <Icon
-                    iconName={commandToIconName(observer.model.commandType)}
-                    className="mr-1 font-weight-bold align-middle"
-                  />
-                  <span className="align-middle">{observer.model.name}</span>
-                </span>
-                {(outputPin && (
-                  <Pin
-                    key={outputPin.key}
-                    observable={pinToObservable(outputPin)}
-                    node={observable}
-                    hideName
-                    onPinsConnect={readOnly ? undefined : onPinsConnect}
-                  />
-                )) || (
-                  <PinGhost
-                    direction={PinDirection.Output}
-                    valueType={PinValueType.Node}
-                  />
-                )}
-              </div>
               <div
-                className="d-flex justify-content-between"
-                style={{ width: "100%" }}
+                className={classNames("card node d-flex flex-column noselect", {
+                  "node-selected": selected,
+                })}
               >
-                <div className="input-pins">
-                  {observer.model.inputPins
-                    .filter((x) => x !== inputPin)
-                    .map((pin) => (
-                      <Pin
-                        key={pin.key}
-                        observable={pinToObservable(pin)}
-                        node={observable}
-                        onPinsConnect={readOnly ? undefined : onPinsConnect}
-                      />
-                    ))}
+                {observer.model.commandType === NodeCommandType.Flow &&
+                  observer.model.subFlowId && (
+                    <button
+                      className="open-flow-button"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        if (onOpenFlow) onOpenFlow(observer.model.subFlowId!);
+                        else history.push(`/flows/${observer.model.subFlowId}`);
+                      }}
+                    >
+                      <Icon iconName="OpenPane" />
+                    </button>
+                  )}
+                <div className="d-flex flex-row justify-content-between">
+                  {(inputPin && (
+                    <Pin
+                      key={inputPin.key}
+                      observable={pinToObservable(inputPin)}
+                      node={observable}
+                      hideName
+                      onPinsConnect={readOnly ? undefined : onPinsConnect}
+                    />
+                  )) || (
+                    <PinGhost
+                      direction={PinDirection.Input}
+                      valueType={PinValueType.Node}
+                    />
+                  )}
+                  <span className="node-name font-weight-bold">
+                    <Icon
+                      iconName={commandToIconName(observer.model.commandType)}
+                      className="mr-1 font-weight-bold align-middle"
+                    />
+                    <span className="align-middle">{observer.model.name}</span>
+                  </span>
+                  {(outputPin && (
+                    <Pin
+                      key={outputPin.key}
+                      observable={pinToObservable(outputPin)}
+                      node={observable}
+                      hideName
+                      onPinsConnect={readOnly ? undefined : onPinsConnect}
+                    />
+                  )) || (
+                    <PinGhost
+                      direction={PinDirection.Output}
+                      valueType={PinValueType.Node}
+                    />
+                  )}
                 </div>
-                <div className="output-pins">
-                  {observer.model.outputPins
-                    .filter((x) => x !== outputPin)
-                    .map((pin) => (
-                      <Pin
-                        key={pin.key}
-                        observable={pinToObservable(pin)}
-                        node={observable}
-                        onPinsConnect={readOnly ? undefined : onPinsConnect}
-                      />
-                    ))}
+                <div
+                  className="d-flex justify-content-between"
+                  style={{ width: "100%" }}
+                >
+                  <div className="input-pins">
+                    {observer.model.inputPins
+                      .filter((x) => x !== inputPin)
+                      .map((pin) => (
+                        <Pin
+                          key={pin.key}
+                          observable={pinToObservable(pin)}
+                          node={observable}
+                          onPinsConnect={readOnly ? undefined : onPinsConnect}
+                        />
+                      ))}
+                  </div>
+                  <div className="output-pins">
+                    {observer.model.outputPins
+                      .filter((x) => x !== outputPin)
+                      .map((pin) => (
+                        <Pin
+                          key={pin.key}
+                          observable={pinToObservable(pin)}
+                          node={observable}
+                          onPinsConnect={readOnly ? undefined : onPinsConnect}
+                        />
+                      ))}
+                  </div>
                 </div>
               </div>
+              {observer.model.subFlowId && (
+                <div
+                  className={classNames("subflow-inline", {
+                    expanded: observer.isExpanded,
+                  })}
+                >
+                  {observer.isExpanded && observer.subFlow && (
+                    <Flow
+                      id={observer.model.subFlowId}
+                      readOnly
+                      preloaded={observer.subFlow}
+                    />
+                  )}
+                </div>
+              )}
             </div>
           </Draggable>
         );


### PR DESCRIPTION
## Summary
- track subflow node expansion state and preload subflow data
- render nested subflow inline with smooth transitions
- add CSS transitions for expand/collapse behavior

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68b5a419ff348321bb48e69f0a1d3c79